### PR TITLE
Fixes #5: Edge Aliasing

### DIFF
--- a/src/VL.Devices.DeckLink/VideoIn.cs
+++ b/src/VL.Devices.DeckLink/VideoIn.cs
@@ -549,7 +549,7 @@ shader YUV2RGB : ImageEffectShader
 {
     stage override float4 Shading()
     {
-	    uint pixel = streams.TexCoord.x / Texture0TexelSize.x;
+	    uint pixel = streams.TexCoord.x / (2 * Texture0TexelSize.x);
 	    bool rightPixel = pixel % 2 == 0;
 	
         float4 uyvy = Texture0.Sample(PointSampler, streams.TexCoord);


### PR DESCRIPTION
Double texture input size.

@azeno Your assessment in #5  was right, it was tested with Decklink Desktop Video v12.x