### PR TITLE
Fix ComputeOnGpu sawtooth edges

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="vvvv-public-feed" value="http://teamcity.vvvv.org/guestAuth/app/nuget/v1/FeedService.svc/" />
+    <add key="vvvv-public-feed" value="https://teamcity.vvvv.org/guestAuth/app/nuget/v1/FeedService.svc/" />
   </packageSources>
 </configuration>

--- a/help/Explanation Overview.vl
+++ b/help/Explanation Overview.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="BAnU6JWtqqeLZ9QOLbI4Ib" LanguageVersion="2020.2.0.284" Version="0.128">
-  <NugetDependency Id="T9VkosbiVDePuzSRd6qV6V" Location="VL.CoreLib" Version="2020.2.0-0284-g8a1fd67a19" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="BAnU6JWtqqeLZ9QOLbI4Ib" LanguageVersion="2025.7.0-0369-g117540fa59" Version="0.128">
+  <NugetDependency Id="T9VkosbiVDePuzSRd6qV6V" Location="VL.CoreLib" Version="2025.7.0-0369-g117540fa59" />
   <Patch Id="GfsGbY95eAGMvjmI34vHU9">
     <Canvas Id="U3U9OBbG4pZPCEORoLS26J" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
     <!--
@@ -15,23 +15,17 @@
       </p:NodeReference>
       <Patch Id="LoZic1cvBTEMwi6EUSNytV">
         <Canvas Id="NyTs6BD6kMRQKSKgIHDUUI" CanvasType="Group">
-          <Node Bounds="604,368,65,19" Id="NkF8H1xBvzNMAupmV8Y53R">
-            <p:NodeReference LastCategoryFullName="VL.Devices.DeckLink" LastSymbolSource="VL.Devices.DeckLink.vl">
+          <Node Bounds="604,270,105,19" Id="NkF8H1xBvzNMAupmV8Y53R">
+            <p:NodeReference LastCategoryFullName="VL.Devices.DeckLink" LastDependency="VL.Devices.DeckLink.vl">
               <Choice Kind="ProcessNode" Name="VideoIn" />
             </p:NodeReference>
+            <Pin Id="OpAcYH35qDZQAeP5SmBifa" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="TcSxOORfBpFOxlwNsAcSLb" Name="Device" Kind="InputPin" />
-            <Pin Id="JDzsNezB6XhMNPIkS1C5JC" Name="Preferred Display Mode" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="VL.Devices.DeckLink" LastSymbolSource="VL.Devices.DeckLink.vl">
-                <Choice Kind="TypeFlag" Name="_BMDDisplayMode" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="DaS9rGVq191QMPMvufXhMB" Name="Preferred Pixel Format" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="VL.Devices.DeckLink" LastSymbolSource="VL.Devices.DeckLink.vl">
-                <Choice Kind="TypeFlag" Name="_BMDPixelFormat" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="JDzsNezB6XhMNPIkS1C5JC" Name="Preferred Display Mode" Kind="InputPin" />
+            <Pin Id="DaS9rGVq191QMPMvufXhMB" Name="Preferred Pixel Format" Kind="InputPin" />
+            <Pin Id="FZiaC2IOHaLOQWf6rSNwOZ" Name="Wait Time" Kind="InputPin" />
             <Pin Id="Bb9eozvOoOfL8ta1Ts8KUr" Name="Convert On GPU" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
@@ -42,75 +36,13 @@
             <Pin Id="SjMx5JzLbafNGszkf5aT9y" Name="Discarded Frames" Kind="OutputPin" />
             <Pin Id="OFeP6yzoDjOLpIE3VSVCSl" Name="Supported Display Modes" Kind="OutputPin" />
           </Node>
-          <Pad Id="StL4zYxw6x5Pfp6k5S45Gq" Comment="Device" Bounds="603,274,150,15" ShowValueBox="true" isIOBox="true" Value="DeckLink Mini Recorder 4K">
-            <p:TypeAnnotation LastCategoryFullName="VL.Devices.DeckLink" LastSymbolSource="VL.Devices.DeckLink.vl">
+          <Pad Id="StL4zYxw6x5Pfp6k5S45Gq" Comment="Device" Bounds="606,121,150,15" ShowValueBox="true" isIOBox="true" Value="DeckLink Mini Recorder 4K">
+            <p:TypeAnnotation LastCategoryFullName="VL.Devices.DeckLink" LastDependency="VL.Devices.DeckLink.vl">
               <Choice Kind="TypeFlag" Name="DeviceEnumEntry" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="531,576,185,19" Id="CfnMesjwXJHLz9AHdzEjsR">
-            <p:NodeReference LastCategoryFullName="Stride.Windowing" LastSymbolSource="VL.Stride.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="RenderWindow" />
-            </p:NodeReference>
-            <Pin Id="RJzVrwb1GUTLLGXuucm0xE" Name="Bounds" Kind="InputPin" DefaultValue="1162, 205, 662, 698">
-              <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Rectangle" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="LyQifVYEcaLN9E7Otd8Xdp" Name="Back Buffer Format" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Graphics.vl">
-                <Choice Kind="TypeFlag" Name="PixelFormat" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="NPEgsshnyJBQZGw7P8kUU8" Name="Depth Buffer Format" Kind="InputPin" />
-            <Pin Id="SBGogLLdyMsPfGoAzTXXi6" Name="Input" Kind="InputPin" />
-            <Pin Id="F7Gbk2a3ZNQMYtutkiCg13" Name="Title" Kind="InputPin" />
-            <Pin Id="BjvkDdt2ia6Nth6i7lvp6o" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
-            <Pin Id="U8jPWf17SWRLegKk9SIbaM" Name="Render View" Kind="InputPin" />
-            <Pin Id="GFjq6EavwN7P2iHCay0VDv" Name="Enabled" Kind="InputPin" />
-            <Pin Id="KYuO9ylJY5UQXt9hOMcR5R" Name="EditMode" Kind="InputPin" />
-            <Pin Id="C6myPrS1o09Ma9mU2tbGDO" Name="Present Interval" Kind="InputPin" />
-            <Pin Id="UvquERLkjeLL9hihLpSygW" Name="Output" Kind="OutputPin" />
-            <Pin Id="Dq0ZwiXlshWP3hcIS0DOEK" Name="Input Source" Kind="OutputPin" />
-            <Pin Id="BszxcqppBb1O3awdhT38S6" Name="Back Buffer" Kind="OutputPin" />
-            <Pin Id="VRtZ7RUm46sPbjeLEgiw9q" Name="Depth Buffer" Kind="OutputPin" />
-          </Node>
-          <Node Bounds="586,466,105,19" Id="GLLQLhTiAfDMQIJ5KV33vU">
-            <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="QuadRenderer" />
-            </p:NodeReference>
-            <Pin Id="I7qa2Bl7FqwODhADOjZ8G6" Name="Transformation" Kind="InputPin" />
-            <Pin Id="ILgRnhtflPgQXA2OtvLge4" Name="Texture" Kind="InputPin" />
-            <Pin Id="CKfhMR8yj2cPk9mAN3uJkm" Name="Color" Kind="InputPin" />
-            <Pin Id="Ln9SSEfKzP0NKT6mVEiUhr" Name="Screen Space" Kind="InputPin" />
-            <Pin Id="IY6MQebETZdOFwoDBnfxdE" Name="Keep Aspect" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="TizAIGiNAaBMIpOmiWGYzH" Name="Alpha Blend" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="LLXIteNphwbPU8LeULo4HM" Name="Layer" Kind="OutputPin" />
-          </Node>
-          <Node Bounds="589,532" Id="RYObY1ruYoaP7Lv6dfODYY">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="ClearRenderer" />
-              <CategoryReference Kind="Category" Name="Rendering" NeedsToBeDirectParent="true">
-                <p:OuterCategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
-              </CategoryReference>
-            </p:NodeReference>
-            <Pin Id="L0FCysObiHIMZKo3RA0UIw" Name="Input" Kind="InputPin" />
-            <Pin Id="AHIDZnifv71Ly6OQJEWebC" Name="Color" Kind="InputPin" />
-            <Pin Id="JoS8IUtbZ3fL0mNgS7O6eh" Name="Enabled" Kind="InputPin" />
-            <Pin Id="L0H2kygeXEnP3HknavEqFz" Name="Output" Kind="StateOutputPin" />
-          </Node>
-          <Node Bounds="480,426,25,19" Id="JrIN6a5t3vlMAR53Ew2TKA">
-            <p:NodeReference LastCategoryFullName="2D.Transform" LastSymbolSource="CoreLibBasics.vl">
+          <Node Bounds="480,426,76,19" Id="JrIN6a5t3vlMAR53Ew2TKA">
+            <p:NodeReference LastCategoryFullName="2D.Transform" LastDependency="CoreLibBasics.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="UniformScale" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -118,20 +50,20 @@
               </CategoryReference>
             </p:NodeReference>
             <Pin Id="AWdgIKzEQmLO8ZNdVMKF3u" Name="Input" Kind="InputPin" />
-            <Pin Id="KEYpdgs1zTPQHhgCyc9kmc" Name="Scaling" Kind="InputPin" DefaultValue="1.71">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <Pin Id="KEYpdgs1zTPQHhgCyc9kmc" Name="Scaling" Kind="InputPin" DefaultValue="1">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="Ick9TAKZ1JsMt7yZ6KJuYW" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="IKXZe4VZYebMLtGs4DbXwa" Comment="Convert On GPU" Bounds="706,316,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+          <Pad Id="IKXZe4VZYebMLtGs4DbXwa" Comment="Convert On GPU" Bounds="706,218,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Boolean" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="E1edCvEo5Z6QBwrAIjWRAH" Bounds="747,332,141,19" ShowValueBox="true" isIOBox="true" Value="Assumes YUV422 8Bit">
-            <p:TypeAnnotation>
+          <Pad Id="E1edCvEo5Z6QBwrAIjWRAH" Bounds="747,234,141,19" ShowValueBox="true" isIOBox="true" Value="Assumes YUV422 8Bit">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -139,6 +71,87 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
+          <ControlPoint Id="Oqp4t8ct660N1Ihm6VJh1A" Bounds="631,150" />
+          <Pad Id="PlXBrCmO4i2M6lVa0Dd8eq" Comment="Preferred Display Mode" Bounds="631,150,177,15" ShowValueBox="true" isIOBox="true" Value="bmdModeHD1080p6000">
+            <p:TypeAnnotation LastCategoryFullName="VL.Devices.DeckLink" LastDependency="VL.Devices.DeckLink.vl">
+              <Choice Kind="TypeFlag" Name="_BMDDisplayMode" />
+            </p:TypeAnnotation>
+          </Pad>
+          <ControlPoint Id="QT1KWLlzvj6OHGmwIZj6tW" Bounds="656,180" />
+          <Pad Id="EVaK4VKt6wnMSsyN5AKvQN" Comment="Preferred Pixel Format" Bounds="656,180,159,15" ShowValueBox="true" isIOBox="true" Value="bmdFormat8BitYUV">
+            <p:TypeAnnotation LastCategoryFullName="VL.Devices.DeckLink" LastDependency="VL.Devices.DeckLink.vl">
+              <Choice Kind="TypeFlag" Name="_BMDPixelFormat" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="QALo3hwyYYHPubtXedr0y7" Comment="Display Mode" Bounds="628,410,177,15" ShowValueBox="true" isIOBox="true" />
+          <Pad Id="MFx4FX0GvyFMSNKPf3zTrL" Comment="Pixel Format" Bounds="646,370,159,15" ShowValueBox="true" isIOBox="true" />
+          <Pad Id="MkdKV5KcMZoMWUzzpbnPF2" Comment="Colorspace" Bounds="666,340,58,15" ShowValueBox="true" isIOBox="true" />
+          <Pad Id="VYYIFgwJd5ONACwa3pcAro" Comment="Discarded Frames" Bounds="686,310,35,15" ShowValueBox="true" isIOBox="true" />
+          <Pad Id="HvqfEc37GnjMEFZTLcuBcV" Comment="Supported Display Modes" Bounds="877,310,201,426" ShowValueBox="true" isIOBox="true" />
+          <Node Bounds="586,570,165,19" Id="KAjjdlH8fQ4LtJwzkVdcpS">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="RenderWindow" />
+            </p:NodeReference>
+            <Pin Id="BlUOUrtFDYhMyj7zqW8WhD" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="NjZ3Zu0zihfOWVCGV2Mnun" Name="Bounds" Kind="InputPin" DefaultValue="1000, 40, 865, 826" IsHidden="true" />
+            <Pin Id="EZJoYvUlp3ULju2m9w5isl" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Tgzy4Wd7LklL3GYLyOf4k7" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+            <Pin Id="LfoNBzdv60OMUoMycYsAOO" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
+            <Pin Id="MflFbioywOsMNS1NoR646F" Name="Back Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="V6WyfCcgLw3PE1QLzJgITi" Name="Depth Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="G69Qz9QWIf5PCValoGi3gm" Name="Multisample Count" Kind="InputPin" IsHidden="true" />
+            <Pin Id="GoCbMF2nTg0PunduekQlxp" Name="Input Priority" Kind="InputPin" IsHidden="true" />
+            <Pin Id="E3ThQT0vzKmOuQPoXNEPk1" Name="Input" Kind="InputPin" />
+            <Pin Id="Gqw7fLiH30OLkx1NKxatBX" Name="Render View" Kind="InputPin" />
+            <Pin Id="Rn88ZypbxskLfAUbULznHi" Name="Title" Kind="InputPin" />
+            <Pin Id="GN6wdFiWPlGQdaBlvjS8BX" Name="Clear Flags" Kind="InputPin" IsHidden="true" />
+            <Pin Id="MbiUxO9ttfxMtZ1fJja4bD" Name="Clear Color" Kind="InputPin" />
+            <Pin Id="OqThOLzQdfFPaToElSdYIj" Name="Clear Depth" Kind="InputPin" IsHidden="true" />
+            <Pin Id="FLP4fJrcdBhPM0KVqqCbi7" Name="Clear Stencil" Kind="InputPin" IsHidden="true" />
+            <Pin Id="N7vMcFW0Lg9Lo1MyYKXanF" Name="Clear" Kind="InputPin" />
+            <Pin Id="IVcHBNYqIouPEQnV4I3xnJ" Name="Edit Mode" Kind="InputPin" />
+            <Pin Id="K1EW9xN4YPZQb8anaGuMMx" Name="Commands" Kind="InputPin" IsHidden="true" />
+            <Pin Id="EJBHqMYFO2cQVFocDFfsro" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
+            <Pin Id="Iw8tuyHkNpdQYxyyDtDynL" Name="Enabled" Kind="InputPin" />
+            <Pin Id="EzZVEpZGMBXLVuwk3A8cNx" Name="Present Interval" Kind="InputPin" />
+            <Pin Id="C5nKqpXNqqPNB9uyWQLz6G" Name="Output" Kind="OutputPin" />
+            <Pin Id="NJeGtkotbMbOY3g3pr2hwj" Name="Client Bounds" Kind="OutputPin" />
+            <Pin Id="RbeFiTNJgXSLRjZ4jE2O3y" Name="Input Source" Kind="OutputPin" />
+            <Pin Id="Aj1mvFEj0yVLWjWAkLgkKj" Name="Back Buffer" Kind="OutputPin" />
+            <Pin Id="SCpqt8kq8TQOQD0pmngicX" Name="Depth Buffer" Kind="OutputPin" />
+            <Pin Id="K3kxR6yuOcQP6xzOPWx5sH" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
+          </Node>
+          <Node Bounds="586,500,145,19" Id="UOZE56ql0xcQLoRe4BDSYE">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="FullscreenQuadRenderer" />
+            </p:NodeReference>
+            <Pin Id="ScCCgYYPE6mMYvmZowWzia" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="OHDlsQRZw0rOuDhYXgpTm0" Name="Transformation" Kind="InputPin" />
+            <Pin Id="VF5uTAQw9ZELMR0y68q1Jz" Name="Texture" Kind="InputPin" />
+            <Pin Id="Efs7JVZYc9bPxol08ejaIo" Name="Sampler" Kind="InputPin" />
+            <Pin Id="Js3jhzbzOCjMkT5cVkPXcf" Name="Sample Mode" Kind="InputPin" />
+            <Pin Id="RBO9Sc2jJuxQPmGXwyI7Xp" Name="Blend State" Kind="InputPin" />
+            <Pin Id="SmEyX6TzbsdMBt5sPsimq7" Name="Color" Kind="InputPin" />
+            <Pin Id="V8lLlvXQdxhPUwYxOnKrqW" Name="Rasterizer State" Kind="InputPin" />
+            <Pin Id="M4XOQiXOZdfMLMYaRotP95" Name="Depth Stencil State" Kind="InputPin" />
+            <Pin Id="VW98W3IfElhPOqKM2Nf6zf" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="480,380,105,19" Id="PIdqAL2H2wNLn7vqr2hdhq">
+            <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="TextureAspectRatio" />
+            </p:NodeReference>
+            <Pin Id="KBAh7AEe1YTNQRVMvkroOj" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="KEHIyP66iiNQBMFGeu6Z8q" Name="Texture" Kind="InputPin" />
+            <Pin Id="OjMnsRM5D5PLW8abyzSWsF" Name="Transformation" Kind="InputPin" />
+            <Pin Id="VjRWPjdhZsYMsJBt8rVPgF" Name="Aspect Ratio Correction Mode" Kind="InputPin" DefaultValue="FitIn" />
+            <Pin Id="J3sJUpBNHZUPEeDP7uFkx1" Name="Anchor" Kind="InputPin" DefaultValue="Center" />
+            <Pin Id="Ov16hRPlYMZPGVjYBnczas" Name="Position" Kind="InputPin" />
+            <Pin Id="Q41yfa8p2SWOdkv6M5OhyG" Name="Size" Kind="InputPin" />
+            <Pin Id="C3W7qeT358oMcgoqhObpFz" Name="Transformation" Kind="OutputPin" />
+          </Node>
         </Canvas>
         <Patch Id="C1i9wtJ5VR1MohC3kb9rAj" Name="Create" />
         <Patch Id="OkacbrZcMxpMXXOQ2CvYzu" Name="Update" />
@@ -147,14 +160,23 @@
           <Fragment Id="E6kvV1cSyAwQc5MaydllYw" Patch="OkacbrZcMxpMXXOQ2CvYzu" Enabled="true" />
         </ProcessDefinition>
         <Link Id="BV8y90gSCtsNZNAEBXqlYz" Ids="StL4zYxw6x5Pfp6k5S45Gq,TcSxOORfBpFOxlwNsAcSLb" />
-        <Link Id="JdFANTWmLMmPnoxFVmnPtx" Ids="L0H2kygeXEnP3HknavEqFz,SBGogLLdyMsPfGoAzTXXi6" />
-        <Link Id="LBrkVsc1DzGOJbEJACHdCa" Ids="Ick9TAKZ1JsMt7yZ6KJuYW,I7qa2Bl7FqwODhADOjZ8G6" />
-        <Link Id="OrJfXdW1IsrLRUsJH9Qx7x" Ids="LLXIteNphwbPU8LeULo4HM,L0FCysObiHIMZKo3RA0UIw" />
-        <Link Id="Fn1Vcsiy7HZNdiN8nqFcAK" Ids="QG3r4M6oHb8Lj9myRIlYjN,ILgRnhtflPgQXA2OtvLge4" />
         <Link Id="VZGO6XLy14kNc5ITfSedpt" Ids="IKXZe4VZYebMLtGs4DbXwa,Bb9eozvOoOfL8ta1Ts8KUr" />
+        <Link Id="DkIWMMPXPR3MCSXviGNLlh" Ids="PlXBrCmO4i2M6lVa0Dd8eq,Oqp4t8ct660N1Ihm6VJh1A,JDzsNezB6XhMNPIkS1C5JC" />
+        <Link Id="SHvnOO6Y567P1acelUdgVu" Ids="EVaK4VKt6wnMSsyN5AKvQN,QT1KWLlzvj6OHGmwIZj6tW,DaS9rGVq191QMPMvufXhMB" />
+        <Link Id="MSBwVRvpZhXPDPcMh78INI" Ids="CO9wLCZGqsYLKghsrjIbCl,QALo3hwyYYHPubtXedr0y7" />
+        <Link Id="IZBEe6RS6rxMZ5QmkGB7im" Ids="BFSwGftr3iaNAFCbqvKGB3,MFx4FX0GvyFMSNKPf3zTrL" />
+        <Link Id="HZ53UsV4sMcQGedjKqjV3A" Ids="AtN0vrwJEQ4MFhysawUiVh,MkdKV5KcMZoMWUzzpbnPF2" />
+        <Link Id="LmwOo18tH7sPKghqriIXI7" Ids="SjMx5JzLbafNGszkf5aT9y,VYYIFgwJd5ONACwa3pcAro" />
+        <Link Id="BFCUfUCkHglNApe0Kn918l" Ids="OFeP6yzoDjOLpIE3VSVCSl,HvqfEc37GnjMEFZTLcuBcV" />
+        <Link Id="NltC6i4BxYALdpWuVJwy4r" Ids="VW98W3IfElhPOqKM2Nf6zf,E3ThQT0vzKmOuQPoXNEPk1" />
+        <Link Id="QkO2UQsDeVWLvXnKv3JRPr" Ids="QG3r4M6oHb8Lj9myRIlYjN,VF5uTAQw9ZELMR0y68q1Jz" />
+        <Link Id="S2iUXfZIF1sLwYnALD7I2m" Ids="Ick9TAKZ1JsMt7yZ6KJuYW,OHDlsQRZw0rOuDhYXgpTm0" />
+        <Link Id="KLCzWsWsvpgLO8zjzJf5sg" Ids="QG3r4M6oHb8Lj9myRIlYjN,KEHIyP66iiNQBMFGeu6Z8q" />
+        <Link Id="GQxClulP3MzLntxtwTZdsk" Ids="C3W7qeT358oMcgoqhObpFz,AWdgIKzEQmLO8ZNdVMKF3u" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="RDq5XSYXcAQPZe0ldqqluz" Location="VL.Stride" Version="0.7.354-g0623c9ee29" />
+  <NugetDependency Id="RDq5XSYXcAQPZe0ldqqluz" Location="VL.Stride" Version="2025.7.0-0369-g117540fa59" />
   <DocumentDependency Id="Ine3tqQm6dCMf0rshe9RGN" Location="../VL.Devices.DeckLink.vl" />
+  <NugetDependency Id="A2KNLYKLvQoQYGyHercwpC" Location="VL.Stride.TextureFX" Version="2025.7.0-0369-g117540fa59" />
 </Document>

--- a/src/VL.Devices.DeckLink/DeviceEnum.cs
+++ b/src/VL.Devices.DeckLink/DeviceEnum.cs
@@ -1,8 +1,10 @@
 ﻿using DeckLinkAPI;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using VL.Lib;
 using VL.Lib.Collections;
@@ -19,20 +21,42 @@ namespace VL.Devices.DeckLink
         {
             var devices = new Dictionary<string, object>();
 
-            var iterator = new CDeckLinkIterator();
-            var deviceList = new List<IDeckLink>();
-            while (true)
+            try
             {
-                iterator.Next(out var deckLink);
-                if (deckLink is null)
-                    break;
+                var iterator = new CDeckLinkIterator();
 
-                if (deckLink is IDeckLinkInput deckLinkInput)
+                if (iterator != null)
                 {
-                    deckLink.GetModelName(out var modelName);
-                    deckLink.GetDisplayName(out var displayName);
-                    devices.Add(displayName, deckLinkInput);
+                    var deviceList = new List<IDeckLink>();
+                    while (true)
+                    {
+                        iterator.Next(out var deckLink);
+                        if (deckLink is null)
+                            break;
+
+                        if (deckLink is IDeckLinkInput deckLinkInput)
+                        {
+                            deckLink.GetModelName(out var modelName);
+                            deckLink.GetDisplayName(out var displayName);
+                            devices.Add(displayName, deckLinkInput);
+                        }
+                    }
                 }
+            }
+            // DeckLink COM-Class not registered (REGDB_E_CLASSNOTREG).
+            catch (COMException ex) when ((uint)ex.ErrorCode == 0x80040154)
+            {
+                
+            }
+            // native dll not found
+            catch (DllNotFoundException ex)
+            {
+               
+            }
+            // Interop load problem
+            catch (TypeLoadException ex)
+            {
+
             }
 
             // Add a default entry which makes it up to the system to select a device

--- a/src/VL.Devices.DeckLink/VideoIn.cs
+++ b/src/VL.Devices.DeckLink/VideoIn.cs
@@ -39,25 +39,41 @@ namespace VL.Devices.DeckLink
                 if (value?.Value != deviceName)
                 {
                     deviceName = value?.Value;
-
-                    var iterator = new CDeckLinkIterator();
                     var inputDevice = default(IDeckLinkInput);
-                    while (true)
-                    {
-                        iterator.Next(out var deckLink);
-                        if (deckLink is null)
-                            break;
 
-                        if (deckLink is IDeckLinkInput deckLinkInput)
+                    try
+                    {
+                        var iterator = new CDeckLinkIterator();
+                        if (iterator != null)
                         {
-                            deckLink.GetModelName(out var modelName);
-                            deckLink.GetDisplayName(out var displayName);
-                            if (displayName == deviceName)
+                            while (true)
                             {
-                                inputDevice = deckLinkInput;
-                                break;
+                                iterator.Next(out var deckLink);
+                                if (deckLink is null)
+                                    break;
+
+                                if (deckLink is IDeckLinkInput deckLinkInput)
+                                {
+                                    deckLink.GetModelName(out var modelName);
+                                    deckLink.GetDisplayName(out var displayName);
+                                    if (displayName == deviceName)
+                                    {
+                                        inputDevice = deckLinkInput;
+                                        break;
+                                    }
+                                }
                             }
                         }
+                    }
+                    // DeckLink COM-Class not registered (REGDB_E_CLASSNOTREG).
+                    catch (COMException ex) when ((uint)ex.ErrorCode == 0x80040154)
+                    {
+
+                    }
+                    // all other
+                    catch (Exception ex)
+                    {
+
                     }
 
                     InputDevice = inputDevice;

--- a/src/VL.Devices.DeckLink/VideoIn.cs
+++ b/src/VL.Devices.DeckLink/VideoIn.cs
@@ -473,7 +473,14 @@ namespace VL.Devices.DeckLink
             }
 
             var shader = this.shader ?? (this.shader = CreateShader(context));
-            shader.SetInput(CurrentVideoFrame);
+
+            // Set the Output Texture as Input0 (right Width e.g 1920)
+            // and CurrentVideoFrame  as Input1 (wrong Width e.g 960)
+            // With this trick the Shader will be invoked with right Width (e.g 1920)
+            // That was the easiest way I found to run TextureFX with the correct width
+            // and not half the width, which in turn led to the sawtooth edges.
+
+            shader.SetInput( current.outputTexture, CurrentVideoFrame);
             shader.SetOutput(current.outputTexture);
             shader.Draw(context);
         }
@@ -498,7 +505,14 @@ namespace VL.Devices.DeckLink
             try
             {
                 var shader = new ImageEffectShader("YUV2RGB");
-                shader.SetInput(CurrentVideoFrame);
+
+                // Set the Output Texture as Input0 (right Width e.g 1920)
+                // and CurrentVideoFrame  as Input1 (wrong Width e.g 960)
+                // With this trick the Shader will be invoked with right Width (e.g 1920)
+                // That was the easiest way I found to run TextureFX with the correct width
+                // and not half the width, which in turn led to the sawtooth edges.
+
+                shader.SetInput(current.outputTexture, CurrentVideoFrame);
                 shader.SetOutput(current.outputTexture);
                 shader.Draw(context);
                 return shader;
@@ -552,10 +566,12 @@ shader YUV2RGB : ImageEffectShader
 {
     stage override float4 Shading()
     {
-	    uint pixel = streams.TexCoord.x / (2 * Texture0TexelSize.x);
+        // use Width (e.g. 1920) from Texture0 ... assigned to outputTexture
+	    uint pixel = streams.TexCoord.x / (Texture0TexelSize.x);
 	    bool rightPixel = pixel % 2 == 0;
 	
-        float4 uyvy = Texture0.Sample(PointSampler, streams.TexCoord);
+        // use Texture1 width half width as input 
+        float4 uyvy = Texture1.Sample(PointSampler, streams.TexCoord);
 	    float y1 = uyvy.a;
 	    float y2 = uyvy.g;
 	    float u = uyvy.b;


### PR DESCRIPTION
ComputeOnGpu did not function correctly because the width of a YUV compressed texture is only half of the actual width.

As a result, the internal TextureFx was only executed with WidhtHalf, which in turn led to sawtooth edges.

For this reason, I now give the internal TextureFX two input textures:
- Texture0, the output texture with the correct width
- Texture1, the actual frame capture with WidthHalf.
- The internal TextureFX then uses Texture1.

catch error in GetEntries when Decklink-SDK or Decklink-Card not available #4 
change vvvv-public-feed to https